### PR TITLE
fix packet reading to add the `header_len` value to the packet's `data_len`

### DIFF
--- a/src/network/mod.rs
+++ b/src/network/mod.rs
@@ -128,7 +128,7 @@ impl GameCommand {
         let header_len = u16::from_be_bytes(bytes[6..8].try_into().unwrap());
         let data_len = u32::from_be_bytes(bytes[8..12].try_into().unwrap());
 
-        let data = bytes[12..12 + data_len as usize].to_vec();
+        let data = bytes[12..12 + data_len as usize + header_len as usize].to_vec();
         Some(GameCommand {
             command_id,
             header_len,


### PR DESCRIPTION
I'll try to explain as well as I can using a picture. Below is a picture of a data packet for a command:

![image](https://github.com/IceDynamix/reliquary/assets/7631687/753a0573-e688-47af-8201-f5991a9063d2)

Each item is labeled. The important parts are the 0x06 to 0x07 bytes (`header_len`) and 0x08 to 0x0B bytes (`data_len`). If you notice, the data start and data end offsets are actually separated by a bit longer than the `data_len`:
0x000000E2 - 0x0000000C = 0xD6. If you add 0x0C (`header_len`) to 0xCA (`data_len`), you get 0xD6.

I saw the other pull request suggesting to skip the first `header_len` bytes after 0x0B, and that's possibly another way to do it. 

I'd warn, however, that since the first 0xC bytes in the data packet do contain protobuf data, it could potentially be important/useful in one way or another down the line. None of the fields are mapped in the .proto file for this command in particular (one of them is the user's UID), but that may not be the case for other .proto files.

This data doesn't seem to be the same across all packets and is specific to each command. It could be some sort of "data preamble" type of information, but I'd rather capture it all than skip it (requires less code changing if .proto files include those fields and we suddenly want to use data in those bytes).
