### PR TITLE
Pin protobuf to 3.4.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ license = "MIT"
 base64 = "0.22"
 etherparse = "0.14"
 kcp = "0.5"
-protobuf = "3.4"
+protobuf = "~3.4.0"
 rand_mt = "4.2"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"


### PR DESCRIPTION
This pins protobuf to version 3.4.0 to match the version the files were generated with, to avoid build errors when a newer minor version (3.5.0) is available